### PR TITLE
ENG-3486 : Stabilizing Serverless support for Python APM

### DIFF
--- a/middleware/config.py
+++ b/middleware/config.py
@@ -37,6 +37,25 @@ class Config:
 
         self.exporter_otlp_endpoint = f"http://{source_service_url}:9319"
         self.resource_attributes = f"{project_name_attr}mw.app.lang=python,runtime.metrics.python=true"
+        
+        # Allowing users to override full OTLP endpoint 
+        # Priority OTEL_EXPORTER_OTLP_ENDPOINT > MW_TARGET
+        mw_target = os.environ.get("MW_TARGET", None)
+        if mw_target is not None and mw_target != "":
+            self.exporter_otlp_endpoint = mw_target
+            
+        exporter_otlp_endpoint = os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT", None)
+        if exporter_otlp_endpoint is not None and exporter_otlp_endpoint != "":
+            self.exporter_otlp_endpoint = exporter_otlp_endpoint
+        
+        # Allowing users to pass Middleware API Key via ENV variable
+        mw_api_key = os.environ.get("MW_API_KEY", None)
+        if mw_api_key is not None and mw_api_key != "":
+            self.access_token = mw_api_key
+        
+        # Passing Middleware API Key as a resource attribute, to validate ingestion requests in serverless setup
+        if self.access_token is not None and self.access_token != "":
+            self.resource_attributes = f"{self.resource_attributes},mw.account_key={self.access_token}"
 
     def get_config(self, section, key, default):
         return self.config.get(section, key, fallback=default)

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ packages = [
 
 setuptools.setup(
     name="middleware-apm",
-    version="0.7.0",
+    version="1.0.0",
     install_requires=requirements,
     author="middleware-dev",
     maintainer="middleware-dev",


### PR DESCRIPTION
- Allowed overriding Target OTLP Endpoint via `OTEL_EXPORTER_OTLP_ENDPOINT`,
  This will have higher priority over `MW_AGENT_SERVICE`  ENV / middleware.ini >  `mw_agent_service`
  Note : With `MW_AGENT_SERVICE` / `mw_agent_service`, we were just able to modify the target host IP, not the whole URL.
  
-  Passed middleware.ini `access_token` value to resource attributes `mw.account_key:<access_token>`, to validate data when Python APM is used in serverless setup

- `access_token` can now be overridden by `MW_API_KEY`